### PR TITLE
Change txSalt to string type to reduce ambiguity

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -205,7 +205,7 @@ FAT-0 Transactions borrow cryptographic elements from Factoid Transaction, inclu
 | marshalledBinarySig | string | Marshalled binary signature of the Factoid Transaction       | Factoid Transaction Validation                             | Y        |
 | signature           | string | ed25519 signature of the transaction                         | Factoid Transaction Validation                             | Y        |
 |                     |        |                                                              |                                                            |          |
-| salt                | string | Random bytes to be hashed into nonce                         | User defined, optional                                     | N*       |
+| salt                | string | Random string to be hashed into nonce                         | User defined, optional                                     | N*       |
 | idNonce             | string | a hash of the transaction information                        | sha256d(tokenID + salt)                                    | N*       |
 | idSignature         | string | ed25519 signature from issuing identity's SK1 key            | ed25519 signature validation (idKey, idNonce, idSignature) | N*       |
 


### PR DESCRIPTION
In a transaction entry, the txNonce is computed from `djb2a(<Token ID> + txSalt)` where addition is defined as string concatenation. However txSalt is defined as a `number` type which requires converting the number to a string. This conversion leads to potential ambiguity since different programming languages may implement string conversion differently. Additionally a JSON number can be a float with arbitrary precision, which could result in differences in the precision of the string conversion. 

By making the `txSalt` field a string type we remove the necessity of this string conversion and reduce ambiguity of the specification. Additionally the `salt` field in the Issuance Entry is a string, so this also increases internal consistency of the specification.