### PR TITLE
Add MIMO tx signing with reduced db sig lookups

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -281,7 +281,7 @@ In the following table `X` is any even number less than `2n`.
 
 ##### Encoding
 All of the RCD and Signature External IDs in a Transaction Entry shall be raw
-data and not use any encoding. The explorer now properly displays External IDs
+data and not use any encoding. The [Factom Explorer](https://explorer.factom.com/) now properly displays External IDs
 that contain raw data as hex encoded data. So there is little reason to encode
 the data we put in the External IDs.
 
@@ -337,7 +337,7 @@ transaction stored in the External IDs of the Transaction Entry, but Coinbase
 transactions must contain a valid signature embedded into the JSON.
 
 A Coinbase transaction is identified by whether it has an input from the
-Coinbase address.
+Coinbase address.x	
 
 #### Computing the current state
 Implementations must maintain the state of the balances of all addresses in


### PR DESCRIPTION
This adds transaction signing for multi-input transactions using Factoid
Address RCD tx signing structure. However unlike the binary Factoid
Transaction datastructure, RCDs and signatures are stored in the
External IDs of the transaction entry.

Additionally this commit greatly improves the specificity of transaction
validation requirements and introduces a convention for numbering
validation requirements. Validation requirements are roughly in order of
computational and then programmatic complexity, this way implementations
that follow the ordering can rule out invalid transactions as
efficiently as possible.

The computation of state is now separated from the description of the
validity rules.

In order to reduce the requirement to search all previous signatures on
valid transactions, the field `declaredHeight` scopes the search to
transactions with the same `declaredHeight`. Validity rule N.2.1 ensures
that implementations only need to store the current and the previously
scanned block of valid transactions in memory. The reason that an
overlap is allowed is because Factom does not guarantee that an entry
will make it into the current block if it is revealed past the block
cutoff time.

TODO: Update the Implementation sections according to these changes.