### PR TITLE
Migrate FATIP-101 & implementing specs to use External IDs.

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -109,12 +109,12 @@ FAT-0 token such as it's name, symbol, supply, and ID.
 
 The official issuance entry is the first well-formed entry on the token's
 issuance chain that has a valid signature from the Issuer's SK1 key identified
-by the Issuer's Identity Chain. There may only be one issuance entry per FAT-0
-token. The issuance entry does not have to be the first entry in the chain.
-Invalid entries are simply ignored.
+by the Issuer's Identity Chain. 
 
-Issuance entries are only valid if the Identity Chain ID matches the Identity
-Chain ID used in the Chain's second External ID (`ExtID[1]`).
+There may only be one issuance entry per FAT-0
+token. It should be noted that due to the implementation of FATIP-100 in this spec, the signed issuance entry cannot be the first entry in the issuance chain, since it's ExtIDS must be exact. The issuance entry does not have to be the first entry in the chain. Invalid entries are simply ignored.
+
+From FATIP-101, the `idNonce` being signed shall be the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of issuance.
 
 
 #### Issuance Entry Content Example
@@ -122,32 +122,33 @@ Chain ID used in the Chain's second External ID (`ExtID[1]`).
 ```json
 {
   "type": "FAT-0",
-  "issuer": "888888dd9e60c1f0216f753caf5c9b5be4c9ca69db27a6c33d30dce3fe5ee709",
   "supply": 10000000,
   "name": "Example Token",
   "symbol": "EXT",
   "salt": "874220a808090fb736f345dd5d67ac26eab94c9c9f51b708b05cdc4d42f65aae",
-  "idSignature": "33467893a440561d96ae27798dc8be291e1ce264d3c6f36f33a0d983e745f1d87db61c77946fe57db3e185f548d51da85106dfec592383a556091dd45f384b0c"
 }
 ```
 
 
 #### Issuance Entry Field Summary & Validation
 
-| Name        | Type   | Description                                                       | Validation                                                               | Required |
-| ----------- | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------ | -------- |
-| type        | string | The type of this token issuance                                   | Must equal 'FAT-0'                                                       | Y        |
-| issuer      | string | The Root Chain ID of the Issuing Identity                         | Identity must exist                                                      | Y        |
-| supply      | number | The maximum possible number of tokens that can be in circulation. | Must be -1 (unlimited), or an integer greater than 0                     | Y        |
-|             |        |                                                                   |                                                                          |          |
-| name        | string | The display name of the token                                     | none                                                                     | N        |
-| symbol      | string | The display symbol of the token                                   | must be A-Z, and 1-4 characters in length                                | N        |
-|             |        |                                                                   |                                                                          |          |
-| salt        | string | Random string to be hashed into nonce                             | user defined. Optional                                                   | Y        |
-| idSignature | string | ed25519 signature from issuing identity's SK1 key                 | ed25519 signature validation (sha256d(tokenID + salt), idKey, signature) | Y        |
+| Name   | Type   | Description                                                  | Validation                                           | Required |
+| ------ | ------ | ------------------------------------------------------------ | ---------------------------------------------------- | -------- |
+| type   | string | The type of this token issuance                              | Must equal 'FAT-0'                                   | Y        |
+| supply | number | The maximum possible number of tokens that can be in circulation. | Must be -1 (unlimited), or an integer greater than 0 | Y        |
+| name   | string | The display name of the token                                | none                                                 | N        |
+| symbol | string | The display symbol of the token                              | must be A-Z, and 1-4 characters in length            | N        |
+| salt   | string | Random string to salt the issuance                           | user defined. Optional                               | N        |
 
 Where sha256d is a double round of sha256 hashing: `sha256d(x) =
 sha256(sha256(x))`
+
+#### Issuance Entry External IDs Summary & Validation
+
+| External ID Index | Type            | Description                                | Validation                                                   | Required |
+| ----------------- | --------------- | ------------------------------------------ | ------------------------------------------------------------ | -------- |
+| 0                 | raw binary data | Raw ed25519 signature of the entry content | ed25519 signature validation (entry content, `idKey`, `ExtID[0]`) | Y        |
+
 
 
 ## Token Transaction Chain

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -229,8 +229,7 @@ entry.
         }
     ],
     "milliTimestamp": 1537450868,
-    "salt": "80d87a8bd5cf2a3eca9037c2229f3701eed29360caa975531ef5fe476b1b70b5",
-    "idSignature": "e391d3dae910ed09cc738f880fac5d573577fdc929d58b059dc4070f6007a3f16084e3d8de1a93a6a894dc7f1261eaaad1e67e3b2b94c6f2aeba64a87b378803"
+    "salt": "80d87a8bd5cf2a3eca9037c2229f3701eed29360caa975531ef5fe476b1b70b5"
 }
 
 ```
@@ -238,22 +237,21 @@ entry.
 
 #### Transaction Entry JSON Field Summary & Validation
 
-| Name                 | Type   | Description                                       | Validation                                                   | Required |
-| -------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------ | -------- |
-| `inputs`             | array  | The inputs of this this transaction               |                                                              | Y        |
-| `inputs[n]`          | object | The output object for this transaction            |                                                              | Y        |
-| `inputs[n].address`  | string | The Factoid address to send tokens from           | Valid public Factoid address                                 | Y        |
-| `inputs[n].amount`   | number | Amount of tokens to send                          | Positive nonzero integer                                     | Y        |
-|                      |        |                                                   |                                                              |          |
-| `outputs`            | array  | The outputs  of this transaction                  |                                                              | Y        |
-| `outputs[n]`         | object | The output object for this transaction            |                                                              | Y        |
-| `outputs[n].address` | string | The Factoid address to send tokens from           | Valid public Factoid address                                 | Y        |
-| `outputs[n].amount`  | number | amount of tokens to send                          | Sum of all output amounts must be `<=` sum of input amounts  | Y        |
-|                      |        |                                                   |                                                              |          |
-| `milliTimestamp`     | number | Milliseconds since epoch 1970.                    | Within 24 hours of the entry's timestamp. In other words it may be 12 hours before or 12 hours after the entry's timestamp | Y        |
-|                      |        |                                                   |                                                              |          |
-| `salt`               | string | Random string to be hashed into nonce             | User defined, optional                                       | N\*      |
-| `idSignature`        | string | ed25519 signature from issuing identity's SK1 key | ed25519 signature validation `(sha256d(tokenID + salt), idKey, idSignature)` | N\*      |
+| Name                 | Type   | Description                             | Validation                                                   | Required |
+| -------------------- | ------ | --------------------------------------- | ------------------------------------------------------------ | -------- |
+| `inputs`             | array  | The inputs of this this transaction     |                                                              | Y        |
+| `inputs[n]`          | object | The output object for this transaction  |                                                              | Y        |
+| `inputs[n].address`  | string | The Factoid address to send tokens from | Valid public Factoid address                                 | Y        |
+| `inputs[n].amount`   | number | Amount of tokens to send                | Positive nonzero integer                                     | Y        |
+|                      |        |                                         |                                                              |          |
+| `outputs`            | array  | The outputs  of this transaction        |                                                              | Y        |
+| `outputs[n]`         | object | The output object for this transaction  |                                                              | Y        |
+| `outputs[n].address` | string | The Factoid address to send tokens from | Valid public Factoid address                                 | Y        |
+| `outputs[n].amount`  | number | amount of tokens to send                | Sum of all output amounts must be `<=` sum of input amounts  | Y        |
+|                      |        |                                         |                                                              |          |
+| `milliTimestamp`     | number | Milliseconds since epoch 1970.          | Within 24 hours of the entry's timestamp. In other words it may be 12 hours before or 12 hours after the entry's timestamp | Y        |
+|                      |        |                                         |                                                              |          |
+| `salt`               | string | Random string to be hashed into nonce   | User defined, optional                                       | N\*      |
 
 **\* = required for coinbase transaction**
 

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -1,6 +1,6 @@
-| FATIP | Title                   | Status | Category       | Author                              | Created   |
-| ----- | ----------------------- | ------ | -------------- | ----------------------------------- | --------- |
-| 0     | Fungible Token Standard | Draft  | Token Standard | Devon Katz \<<devonk@dbgrow.com>\>f | 7-23-2018 |
+| FATIP | Title                   | Status | Category       | Author                             | Created   |
+| ----- | ----------------------- | ------ | -------------- | ---------------------------------- | --------- |
+| 0     | Fungible Token Standard | Draft  | Token Standard | Devon Katz \<<devonk@dbgrow.com>\> | 7-23-2018 |
 
 
 [TOC]
@@ -114,7 +114,7 @@ by the Issuer's Identity Chain.
 There may only be one issuance entry per FAT-0
 token. It should be noted that due to the implementation of FATIP-100 in this spec, the signed issuance entry cannot be the first entry in the issuance chain, since it's ExtIDS must be exact. The issuance entry does not have to be the first entry in the chain. Invalid entries are simply ignored.
 
-From FATIP-101, the `idNonce` being signed shall be the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of issuance.
+From FATIP-101, the `idNonce` being signed shall be the `chainID` of the issuance chain concatenated with the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of issuance.
 
 
 #### Issuance Entry Content Example
@@ -145,9 +145,9 @@ sha256(sha256(x))`
 
 #### Issuance Entry External IDs Summary & Validation
 
-| External ID Index | Type            | Description                                | Validation                                                   | Required |
-| ----------------- | --------------- | ------------------------------------------ | ------------------------------------------------------------ | -------- |
-| 0                 | raw binary data | Raw ed25519 signature of the entry content | ed25519 signature validation (entry content, `idKey`, `ExtID[0]`) | Y        |
+| External ID Index | Type            | Description                                                  | Validation                                                   | Required |
+| ----------------- | --------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
+| 0                 | raw binary data | Raw ed25519 signature output of signing issuance `chainID` + entry content. | ed25519 signature validation (`chainID`+ entry content, `idKey`, `ExtID[0]`) | Y        |
 
 
 

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -114,7 +114,7 @@ by the Issuer's Identity Chain.
 There may only be one issuance entry per FAT-0
 token. It should be noted that due to the implementation of FATIP-100 in this spec, the signed issuance entry cannot be the first entry in the issuance chain, since it's ExtIDS must be exact. The issuance entry does not have to be the first entry in the chain. Invalid entries are simply ignored.
 
-From FATIP-101, the `idNonce` being signed shall be the `chainID` of the issuance chain concatenated with the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of entry to Factom.
+From FATIP-101, the `data` being signed shall be the chainID of the issuance chain concatenated with the entry content. The `issuer` shall be the hex encoded Issuer Identity Root Chain ID used in chain ID derivation, and the `IDKey` used shall be the IDKey of `issuer` at the time of entry to Factom.
 
 
 #### Issuance Entry Content Example

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -114,7 +114,7 @@ by the Issuer's Identity Chain.
 There may only be one issuance entry per FAT-0
 token. It should be noted that due to the implementation of FATIP-100 in this spec, the signed issuance entry cannot be the first entry in the issuance chain, since it's ExtIDS must be exact. The issuance entry does not have to be the first entry in the chain. Invalid entries are simply ignored.
 
-From FATIP-101, the `idNonce` being signed shall be the `chainID` of the issuance chain concatenated with the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of issuance.
+From FATIP-101, the `idNonce` being signed shall be the `chainID` of the issuance chain concatenated with the entry content, and the `IDKey` used shall be the IDKey of the issuer at the time of entry to Factom.
 
 
 #### Issuance Entry Content Example
@@ -259,27 +259,29 @@ entry.
 
 
 #### External IDs
-With the exception of coinbase transactions, Transaction Entries must include
-two External IDs for every input address listed in the transaction: the RCD
-that hashes to the corresponding input address, and a signature.
+Transaction Entries must include two External IDs for every input address listed in the transaction: the RCD
+that hashes to the corresponding input address, and a signature. 
 
 Implementations should ignore any External IDs after the first `2n`, where `n`
-is the number of input addresses. This allows a user to optionally append any
-additional External IDs.
+is the number of input addresses with respect to Factoid address signing & verification process. This allows a user to optionally append any additional External IDs.
+
+In the case of coinbase transactions, the last External ID is used to hold a signature of the issuing identity as per [FATIP-101](101.md). The `idNonce` being signed shall be the transaction `chain ID` concatenated with the entry content. The `IDKey` shall be the issuing identity's IDKey at the time of entry into Factom.
 
 In the following table `X` is any even number less than `2n`.
 
-| External ID Index | External ID Value (RAW DATA)                                   |
-| ----------------- | ----------------------------------------------------------------- |
-| 0                 | RCD corresponding to `input[0].address`                           |
-| 1                 | ed25519 signature by key of RCD in preceding External ID |
-| ...               |                                                                   |
-| `X`               | RCD corresponding to `input[X/2].address`                         |
-| `X + 1`           | ed25519 signature by key of RCD in preceding External ID |
-|                   |                                                                   |
+| External ID Index          | External ID Value (RAW DATA)                                 |
+| -------------------------- | ------------------------------------------------------------ |
+| 0                          | RCD corresponding to `input[0].address`                      |
+| 1                          | ed25519 signature by key of RCD in preceding External ID     |
+| ...                        |                                                              |
+| `X`                        | RCD corresponding to `input[X/2].address`                    |
+| `X + 1`                    | ed25519 signature by key of RCD in preceding External ID     |
+| `ExtIds[ExtID.length - 1]` | Raw binary ed25519 signature output of signing transaction `chainID` + entry content.  ed25519 signature validation (`chainID`+ entry content, `idKey`, `ExtID[0]`) |
+
 
 
 ##### Encoding
+
 All of the RCD and Signature External IDs in a Transaction Entry shall be raw
 data and not use any encoding. The [Factom Explorer](https://explorer.factom.com/) now properly displays External IDs
 that contain raw data as hex encoded data. So there is little reason to encode

--- a/fatips/101.md
+++ b/fatips/101.md
@@ -40,10 +40,8 @@ data using the identity's private keys.
 
 ## Cryptographic Material
 
-For each piece of data that needs to be signed and authenticated by a digital
-identity (i.e. issuance, coinbase transaction, new tokens) standardized field
-names are used for each piece of cryptographic material required for the
-signature authentication process.
+For something to be signed and authenticated by a digital
+identity (i.e. issuance, coinbase transaction, new tokens), several pieces data are specified:
 
 
 ### IDKey
@@ -53,12 +51,10 @@ verify signatures of the signing identity. The IDKey can be found as the 4th
 ExtID in the Identity's registration entry. The registration entry is expected
 to be the second entry in the identity's root chain.
 
-The IDKey is implicit based on the context, and is not necessarily explicitly
-included in datastructures.  It is left up to inheriting specs to define how to
-denote the signing identity's root chain ID.
+The IDKey is implicit based on the context, and should not be explicitly
+included in any datastructures of inheriting.  Specs should denote the signing identity's root chain ID so that applications can determine the signer's IDKey using Factom's digital identity protocol.
 
-For example, in FAT-0 and other standards the `issuer` field in the token
-issuance entry is the root chain ID of the issuing identity.
+For example, in FATIP-0's implementation of FATIP-100, the issuer's ID is integrated into the derivation of the token's chains.
 
 
 ### Nonce
@@ -75,20 +71,29 @@ included, it should be under the field `idNonce`.
 
 The signature is the output of the ed25519 signature function. It's inputs are
 the Identity's first ed25519 private key (SK1), and the Nonce. It's output is
-the signature of the digital identity. It can be verified using the publicly
+the binary signature of the digital identity. It can be verified using the publicly
 available IDKey, Signature, and Nonce.
 
-The nonce is always stored under the field name `idSignature`.
+The nonce is always stored as raw binary data under the last External ID of the entry containing relevant data/signing material.
 
-
-### Example
+### Example Entry
 
 ```
+Entry Content:
 {
-	"idNonce": "7d6920cecc97a105a93763800c692afaf40a87d42c4f505b4a226c0f0e5a7a43",
-	"idSignature": "8122b4c0a26e82100ff2583c3d200e9a731b9d5a7ca8674e57589b353348a5df89625e64a23758b71e83ba89ff6fb0e6b7913924554141a25523d8180f022802"
+	"issuer": "888888dd9e60c1f0216f753caf5c9b5be4c9ca69db27a6c33d30dce3fe5ee709"
+	"idNonce": "7d6920cecc97a105a93763800c692afaf40a87d42c4f505b4a226c0f0e5a7a43"
 }
+
+Entry External IDs:
+ExtIDS[ExtIDS.length - 1] = ,^ ²¤ç?M¼Wý*ÉÜ6¿áXzâãZHxÉLrÉÕ[ZXt|7µlÝ£X¯rÇgcóþu:SVlVÝ¸z c·þÉàÌÅD×DøF£v5Ò¨9(¶àEMAçZÔtUÆ»Ð§(ÃÖw|Öæ<kw0KõCT¿º^ItÂûIñ)nÉSpã²¯ZÁON 'Þ_}§C<d(ÅÀ-Tï-åzc÷%ÎüI×rFÖ¼);qÇ¡/f 5Àñ 7IÜÌÄ]Æ|ÊÒZ®}òz:?º_í~¶4/Îb§:ýyH¢NG×w½uLÁ§¡>[1ðd®8+¶èýP?ÄîwøéKí',nÚNk­º ôèåÜÆ°MZsÊÓ9Ö\ÂaÞ0@¦¸Å¶ÏaÚYOßþjØ{9¸Ëé *ZWÐs.ÒÌSü(Ý
+FãîõÀ!-ôü"áBÿø-ðßåÑÈWèùWÙq?âÎp%a_p2p]¹ÊækFÿ"«?àë`ýY"o×µ[pÿÑõêL¸DòI¶¥)p¸¡K¿Áî1|k³	XQý`h4ä¾[4ZR ®x
 ```
+
+- `content.issuer` - The hex encoded Root Chain ID of the signing identity
+- `content.idNonce` - The data to sign
+- `ExtIDS[ExtIDS.length - 1]` - The raw binary ed25519 signature output of `content.idNonce`
+
 
 
 # Implementation

--- a/fatips/101.md
+++ b/fatips/101.md
@@ -40,8 +40,8 @@ data using the identity's private keys.
 
 ## Cryptographic Material
 
-For something to be signed and authenticated by a digital
-identity (i.e. issuance, coinbase transaction, new tokens), several pieces data are specified:
+For something to be signed and authenticated by a digital identity (i.e.
+issuance, coinbase transaction, new tokens), several pieces data are specified:
 
 
 ### IDKey
@@ -52,9 +52,13 @@ ExtID in the Identity's registration entry. The registration entry is expected
 to be the second entry in the identity's root chain.
 
 The IDKey is implicit based on the context, and should not be explicitly
-included in any datastructures of inheriting specifications. Inheriting specifications should denote the signing identity's root chain ID so that applications can determine the signer's IDKey using Factom's digital identity protocol.
+included in any datastructures of inheriting specifications. Inheriting
+specifications should denote the signing identity's root chain ID so that
+applications can determine the signer's IDKey using Factom's digital identity
+protocol.
 
-For example, in FATIP-0's implementation of FATIP-100, the issuer's ID is integrated into the derivation of the token's chains.
+For example, in FATIP-0's implementation of FATIP-100, the issuer's ID is
+integrated into the derivation of the token's chain IDs.
 
 
 ### Nonce
@@ -71,27 +75,31 @@ included, it should be under the field `idNonce`.
 
 The signature is the output of the ed25519 signature function. It's inputs are
 the Identity's first ed25519 private key (SK1), and the Nonce. It's output is
-the binary signature of the digital identity. It can be verified using the publicly
-available IDKey, Signature, and Nonce.
+the binary signature of the digital identity. It can be verified using the
+publicly available IDKey, Signature, and Nonce.
 
-The nonce is always stored as raw binary data under the last External ID of the entry containing relevant data/signing material.
+The signature is always stored as raw binary data under the last External ID of
+the entry containing relevant data/signing material.
 
 ### Example Entry
 
+#### Entry Content:
 ```
-Entry Content:
 {
 	"issuer": "888888dd9e60c1f0216f753caf5c9b5be4c9ca69db27a6c33d30dce3fe5ee709"
 	"idNonce": "7d6920cecc97a105a93763800c692afaf40a87d42c4f505b4a226c0f0e5a7a43"
 }
+```
 
-Entry External IDs:
+#### Entry External IDs:
+```
 ExtIDS[ExtIDS.length - 1] = < Binary 1 8 0 0 211 74 47 ... 9 182 >
 ```
 
 - `content.issuer` - The hex encoded Root Chain ID of the signing identity
 - `content.idNonce` - The data to sign
-- `ExtIDS[ExtIDS.length - 1]` - The raw binary ed25519 signature output of `content.idNonce`
+- `ExtIDS[ExtIDS.length - 1]` - The raw binary ed25519 signature output of
+  `content.idNonce`
 
 
 

--- a/fatips/101.md
+++ b/fatips/101.md
@@ -44,6 +44,22 @@ For something to be signed and authenticated by a digital identity (i.e.
 issuance, coinbase transaction, new tokens), several pieces data are specified:
 
 
+
+### Data
+
+The data to sign. It should be unique so as to produce a unique
+signature. It's recommended to structure the data being signed so as to prevent signature replay attacks. For example, in [FATIP-0](0.md) where FATIP-101 is extended, the data to sign is concatenated with the chainId the signature resides on, so as to prevent cross chain replay.
+
+The data to sign may not always be explicitly stored. It's up to the implementing spec
+to define how to derive the data and if it's necessary to include it. If it is
+included in JSON, it should be under the field name `data`.
+
+
+
+### Identity Root Chain ID
+
+The Factom ChainID of the identity that will sign `data`. It's required to know the root chain ID of the identity in any implementing standard so that the signed data can be verified. It's not required to specify the signing identity's root chain ID explicitly in JSON, however, it must be known through some means. For example, [FATIP-0](0.md) includes the root chain ID as part of it's Chain ID derivation scheme([FATIP-101](101.md)), so it is known already.  If it is desired to specify the signing identity's root chain ID in JSON, it should be under the field `issuer`. 
+
 ### IDKey
 
 The IDKey is the preimage of the signing identity's identity key. It is used to
@@ -61,14 +77,6 @@ For example, in FATIP-0's implementation of FATIP-100, the issuer's ID is
 integrated into the derivation of the token's chain IDs.
 
 
-### Nonce
-
-The nonce is the data to sign. It should be unique so as to produce a unique
-signature.
-
-The nonce may not always be explicitly stored. It's up to the implementing spec
-to define how to derive the nonce and if it's necessary to include it. If it is
-included, it should be under the field `idNonce`.
 
 
 ### Signature
@@ -86,8 +94,8 @@ the entry containing relevant data/signing material.
 #### Entry Content:
 ```
 {
-	"issuer": "888888dd9e60c1f0216f753caf5c9b5be4c9ca69db27a6c33d30dce3fe5ee709"
-	"idNonce": "7d6920cecc97a105a93763800c692afaf40a87d42c4f505b4a226c0f0e5a7a43"
+	"data": "7d6920cecc97a105a93763800c692afaf40a87d42c4f505b4a226c0f0e5a7a43",
+	"issuer":"888888dd9e60c1f0216f753caf5c9b5be4c9ca69db27a6c33d30dce3fe5ee709"
 }
 ```
 
@@ -96,10 +104,10 @@ the entry containing relevant data/signing material.
 ExtIDS[ExtIDS.length - 1] = < Binary 1 8 0 0 211 74 47 ... 9 182 >
 ```
 
-- `content.issuer` - The hex encoded Root Chain ID of the signing identity
-- `content.idNonce` - The data to sign
+- `content.data` - The data to sign
+- `content.issuer` The root chain ID of the singing identity
 - `ExtIDS[ExtIDS.length - 1]` - The raw binary ed25519 signature output of
-  `content.idNonce`
+  `content.data`
 
 
 

--- a/fatips/101.md
+++ b/fatips/101.md
@@ -52,7 +52,7 @@ ExtID in the Identity's registration entry. The registration entry is expected
 to be the second entry in the identity's root chain.
 
 The IDKey is implicit based on the context, and should not be explicitly
-included in any datastructures of inheriting.  Specs should denote the signing identity's root chain ID so that applications can determine the signer's IDKey using Factom's digital identity protocol.
+included in any datastructures of inheriting specifications. Inheriting specifications should denote the signing identity's root chain ID so that applications can determine the signer's IDKey using Factom's digital identity protocol.
 
 For example, in FATIP-0's implementation of FATIP-100, the issuer's ID is integrated into the derivation of the token's chains.
 
@@ -86,8 +86,7 @@ Entry Content:
 }
 
 Entry External IDs:
-ExtIDS[ExtIDS.length - 1] = ,^ ²¤ç?M¼Wý*ÉÜ6¿áXzâãZHxÉLrÉÕ[ZXt|7µlÝ£X¯rÇgcóþu:SVlVÝ¸z c·þÉàÌÅD×DøF£v5Ò¨9(¶àEMAçZÔtUÆ»Ð§(ÃÖw|Öæ<kw0KõCT¿º^ItÂûIñ)nÉSpã²¯ZÁON 'Þ_}§C<d(ÅÀ-Tï-åzc÷%ÎüI×rFÖ¼);qÇ¡/f 5Àñ 7IÜÌÄ]Æ|ÊÒZ®}òz:?º_í~¶4/Îb§:ýyH¢NG×w½uLÁ§¡>[1ðd®8+¶èýP?ÄîwøéKí',nÚNk­º ôèåÜÆ°MZsÊÓ9Ö\ÂaÞ0@¦¸Å¶ÏaÚYOßþjØ{9¸Ëé *ZWÐs.ÒÌSü(Ý
-FãîõÀ!-ôü"áBÿø-ðßåÑÈWèùWÙq?âÎp%a_p2p]¹ÊækFÿ"«?àë`ýY"o×µ[pÿÑõêL¸DòI¶¥)p¸¡K¿Áî1|k³	XQý`h4ä¾[4ZR ®x
+ExtIDS[ExtIDS.length - 1] = < Binary 1 8 0 0 211 74 47 ... 9 182 >
 ```
 
 - `content.issuer` - The hex encoded Root Chain ID of the signing identity

--- a/fatips/102.md
+++ b/fatips/102.md
@@ -61,9 +61,9 @@ Each entry is signed by the token issuer's digital identity. FAT tokens may
 only be publicly indexed by the issuing identity.
 
 
-#### ID Nonce
+#### Signed Data
 
-`idNonce` specified as per [FATIP-101](101) is derived as follows:
+`data` specified as per [FATIP-101](101) is derived as follows:
 
 ```
 idNonce = sha256(tokenid + salt)


### PR DESCRIPTION
**Changes:**

- Move ID signature in FATIP-101 to use the last External ID in the entry, and use un-encoded binary signature data instead of hex
- Improved documentation clarity improvement in FATIP-101
- Move FATIP-0's impmentation of FATIP-101 to new structure
- FATIP-0's issuance entry signature is now of the entire entry content instead of sha256d(tokenID + salt), since we now have no data recursion problem :wink:. This structure follows FATIP-0's tx entry signing methodology better.