### PR TITLE
FATIP-2 Pegged Asset Token Standard

### DIFF
--- a/FATIPS.md
+++ b/FATIPS.md
@@ -2,7 +2,7 @@
 
 # Factom Asset Token Improvement Proposals :gear:
 
-[![](https://img.shields.io/badge/FAT%20Standards-5-brightgreen.svg?style=for-the-badge)](FATIPS.md)
+[![](https://img.shields.io/badge/FAT%20Standards-7-brightgreen.svg?style=for-the-badge)](FATIPS.md)
 
 [![Discord](https://img.shields.io/discord/479606362507313152.svg?style=for-the-badge)](https://discord.gg/8ADPfSc)
 
@@ -28,9 +28,9 @@ defines the FATIP process.
 
 ## Work In Progress
 
-| FATIP | Name | Category |
-| ----- | ---- | -------- |
-|       |      |          |
+| FATIP | Name                        | Category       |
+| ----- | --------------------------- | -------------- |
+| 2     | Pegged Asset Token Standard | Token Standard |
 
 
 ## Draft

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ A non-fungible asset token standard.
   - Every token is unique, and can have unique properties
   - Tokens have a history of the addresses they've resided at
 
+### [**FAT-2**](fatips/2.md)
+
+Pegnet: Pegged Asset Token Standard
+
+
+
 
 # Getting Started
 

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -1,0 +1,199 @@
+| FATIP | Title                       | Status | Category       | Author               | Created   |
+| ----- | --------------------------- | ------ | -------------- | -------------------- | --------- |
+| 2     | Pegged Asset Token Standard | WIP    | Token Standard | Pegnet Working Group | 7-17-2019 |
+
+
+
+# Summary
+
+From the [PegNet Whitepaper](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#heading=h.b48un57wbewg):
+
+> PegNet is a Pegged Token Network, and it leverages simple game theory and a set of pegged assets that self reinforce each other.  The network provides a mechanism for managing payments, treasury allocations, and budgets across jurisdictions without requiring expensive and slow processes through external parties such as financial institutions, payment processors, exchanges, etc.  
+
+
+
+# Motivation
+
+From the Pegnet Whitepaper:
+
+> Pegged tokens are generally useful for payments, treasury management, exchanges, and wealth preservation.  A Pegged Token network defines a set of pegged tokens, which reflect real market assets such as currencies, precious metals, other cryptocurrency assets, commodities, etc.  For example, a token pegged to USD can be used to make USD purchases, and both the buyer and seller can be assured of the payment with the pegged value will be very close to equal to the dollar equivalent.  For companies holding cryptocurrency assets, the ability to convert parts of those assets into a dollar peg can help to preserve capital when the cryptocurrency market is low.  
+>
+> [...]
+>
+> Pegging to cryptocurrencies can facilitate transactions representing Bitcoin or other cryptocurrency values without the transaction limitations that might exist on the those  blockchains.  Pegging values to other commodities or assets are possible, expanding the use cases for a Pegged Token Network.
+
+# Specification
+
+### Oracle Price Records (OPR)
+
+The pegged asset token uses Oracle Price Record entries, or OPR's, as the main vehicle for oraclizing and forming consensus on exchange rates. An OPR is composed of several core components:
+
+- An answer to a proof of work question
+- Asset exchange rates as witnessed by the miner
+- A payout address for rewards
+
+Miners submit valid OPR entries to the OPR chain each block in hopes of winning a multi-party proof of work problem that rewards in the base token: PNT.
+
+#### OPR Chain
+
+A single Factom chain is defined to house OPR entries depending on test or production chains, defined as the chain with hex encoded External IDs in zero-indexed order:
+
+- `5065674e6574` - "Pegnet" in ascii
+- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+
+Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
+
+#### OPR Entry
+
+Each OPR entry must contain an a valid solution to a LXRHash based proof of work problem (challenge) based on the Factom network block height height. For example:
+
+```
+Factom Network Height: 3033
+Expected Solution (Prefix?): <PREFIX>
+Winning Answer: <ANSWER>
+```
+
+The proof of work solution is `<ENCODING>` encoded in the 0th External ID of the OPR entry.
+
+#####  Content Example & Validation
+
+```json
+{
+    "previous": [
+        "6ZeCoXShJ4hdVJNfTvK9azESibUgLxjBGn5ceEU5x3Ae"
+    ],
+    "reward": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
+    "rates":{
+    	"PNT": 0,
+    	"USD": 0,
+    	"EUR": 0,
+    	"JPY": 0,
+    	"FCT": 5.743
+    }
+}
+```
+
+| Name       | Type   | Description                                               | Validation                                                   | Required |
+| ---------- | ------ | --------------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| `previous` | array  | Previous winning OPR Factom entry hashes                  | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
+| `reward`   | string | The public Factoid address to credit the mining reward to | Must be a valid public Factoid address.                      | Y        |
+| `rates`    | object | The witnessed exchange rates by the miner                 | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
+
+##### External ID Validation
+
+| Index | Description                                                 | Encoding     | Example                                                      |
+| ----- | ----------------------------------------------------------- | ------------ | ------------------------------------------------------------ |
+| 0     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
+
+
+
+#### OPR Grading Algorithm
+
+**NEED MORE INFO HERE**
+
+
+
+### Token Model
+
+#### FAT-0
+
+The pegged asset token standard uses FAT-0 based tokens to represent pegged assets. Trading of terminal pegged assets from address to address will take place on FAT-0 tokens, while conversions inside an address from pegged asset to pegged asset will take place on the central pegnet chain.
+
+To be compatible with the pegged asset token standard a FAT-0 token must be issued with the parameters laid out in the [FAT-0 Spec](0.md) details on the pegged asset network compatibility section. The Pegnet pair string shall be the token's ID
+
+Namely, the FAT-0 token must be initialized by the anonymous "system issuer" identity chain `8888880000000000000000000000000000000000000000000000000000000000` which is un-mineable. This signifies that the pegged asset token system has issuer control over the tokens on that standard.
+
+For example, to issue the base PNT token the FAT-0 token will have the following traits:
+
+- ExtId 0 (Issuer ID) - `8888880000000000000000000000000000000000000000000000000000000000`
+
+- ExtId 1 (Token ID) - `PNT`
+- Content - Unchanged
+
+
+
+### Conversions
+
+Conversions represent a specialized type of transaction that atomically converts one terminal pegged FAT-0 asset into another at the current OPR based exchange rate. Conversions happen inside an address and do not transact tokens between peers.
+
+#### Conversion Chain
+
+Each pegged network shall have it's own conversion chain, defined using the same network string as the OPR chain. For example, the Testnet conversion chain is defined as the following hex encoded External IDs:
+
+- `5065674e6574` - "Pegnet" in ascii
+- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+- `436F6E76657273696F6E73` - "Conversions" in ascii
+
+#### Conversion Entry
+
+##### Content Example & Validation
+
+```json
+{
+	"address": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
+    "from": "PNT",
+    "to": "FCT",
+    "amount": 10.021,
+    "metadata": "I want Factom!"
+}
+```
+
+| Name       | Type   | Description                                               | Validation                                            | Required |
+| ---------- | ------ | --------------------------------------------------------- | ----------------------------------------------------- | -------- |
+| `address`  | string | The Public Factoid address to convert pegged tokens on    | Must be a valid public Factoid address                | Y        |
+| `from`     | string | The pegged asset token ID to convert from                 | Must correspond to a valid issued pegged FAT-0 token  | Y        |
+| `to`       | string | The pegged asset token ID to convert to from `from`       | Must correspond to a valid issued pegged FAT-0 token` | Y        |
+| `amount`   | number | The amount of `from` to use as an input to the conversion | Must be greater than `0`                              | Y        |
+| `metadata` | any    | Arbitrary user defined metadata for the conversion        | Must be valid JSON                                    | N        |
+
+##### Implicit Base Token Conversion
+
+The pegged asset token uses the PNT base token to describe exchange rates. Since all conversions are in ratio of the base token, a conversion using `from` equal to FCT and `to` equal to USD have an implicit conversion to PNT as an intermediary at the current OPR exchange rate.
+
+##### Signing
+
+Conversions are signed according to [FATIP-103](103.md). The signing set is
+the key corresponding to `address` field. The conversion must include an RCD/Signature pair for the source address of the conversion. Signatures and RCDs are defined in the External IDs of the conversion entry as laid out in FATIP-103.
+
+#### Conversion Validation
+
+Conversions must meet all of the following criteria to be valid.
+
+General Criteria:
+
+- The content of the entry must be a single well-formed JSON.
+- The JSON must contain all required fields listed in the above table, all fields and their members must be of the correct type. No unspecified fields may be present. No duplicate field names are allowed.
+- The entry hash of the conversion entry must be unique among all
+  previously valid conversions of the pegged asset token.
+- The External IDs must follow the cryptographic and structural
+  requirements defined by [FATIP-103](103.md) for the `address` input
+
+Specific Criteria:
+
+- Pegged token `from` must exist and be issued
+- Pegged token `to` must exist and be issued
+- `address` must own at least `amount` of pegged token `from` for the conversion to be valid
+
+
+
+If all criteria is met, the following occurs as a single atomic operation:
+
+- `amount` of token `from` is burnt (destroyed) in address `address`
+- `from` is converted to PNT (interim) at the OPR exchange rate
+- Interim PNT is expended to create `to`  via coinbase transaction at the OPR exchange rate
+
+The conversion is complete.
+
+
+
+# Implementation
+
+[Pegnet Project](https://github.com/pegnet/pegnet)
+
+
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This PR and standard lays out the base data structures and cryptography for the Pegged Asset Token Standard (Pegnet).

[Pegnet Whitepaper](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#heading=h.a9cp1ddntqml)
[Pegnet Mining Paper](https://docs.google.com/document/d/1F0cPSDU_aIkAvbd6T62rV0ZRFGgP0O5mpYEHntFAx-A/edit)
[Pegnet Project](https://github.com/pegnet/pegnet)
[Pegnet Discord](https://discord.gg/c83QTcY)

FAT-2 Describes a pegged token system allowing atomic conversions between a specialized type of FAT-0 token issuance controlled autonomously by the pegged asset token protocol, giving the protocol the authority to mint and burn tokens without an issuer according to the OPR grading algorithm and conversion protocol(s). This has the added benefit of being compatible with existing FAT tooling and wallets built as part of Factom protocol grants.

A simplified OPR data structure is proposed with the following improvements over the existing [Existing OPR Entry Structure From The Mainnet](https://explorer.factom.com/chains/b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab/entries/f1e576b57fc9084d6ecb9609b613aa13a86ba7ed21c1e4ee9aab00c9c1f16bf2):
- Overall lowercasing and shortening of keys to save bytes & fit more witnessed records eventually
- Key `OPRChainID` removed, as this can be inferred directly from the OPR chain the OPR entry was found on
- Key `Dbht` removed, as this can be inferred directly from the OPR entry as it is scanned from the blockchain
- Key `WinningPreviousOPR` shortened to `previous`
- Key `CoinbasePNTAddress` changed to `reward`
- Key `FactomDigitalID` removed, as I can't find any functionality that requires it
- All exchange rates are moved out of the JSON root into an object under key `rates` to avoid ambiguity with other keys used for system operations. If pegnet is to eventually support dynamic (new and deprecating old) currency symbols there is not necessarily a guarantee that whatever new symbol is decided, wouldn't collide with an existing key cause issues. We may expect this set of symbols to grow so It makes sense to give it it's own namespace in the JSON.

A conversion data structure is proposed that supports single conversion of assets inside an address. For example, if `FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC` contains a nonzero balance pegged FAT-0 tokens PNT and USD, a conversion entry converts PNT to USD atomically at that address. Conversions do not transact tokens between addresses or parties.
