### PR TITLE
FATIP-2 pegged asset token standard updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore common artifacts of editing
+#
+# Binaries for programs and plugins, merges, tools
+*.idea
+*.dat
+*.orig
+*.txt
+
+# Goland
+.idea/*

--- a/FATIPS.md
+++ b/FATIPS.md
@@ -2,7 +2,7 @@
 
 # Factom Asset Token Improvement Proposals :gear:
 
-[![](https://img.shields.io/badge/FAT%20Standards-5-brightgreen.svg?style=for-the-badge)](FATIPS.md)
+[![](https://img.shields.io/badge/FAT%20Standards-7-brightgreen.svg?style=for-the-badge)](FATIPS.md)
 
 [![Discord](https://img.shields.io/discord/479606362507313152.svg?style=for-the-badge)](https://discord.gg/8ADPfSc)
 
@@ -28,9 +28,9 @@ defines the FATIP process.
 
 ## Work In Progress
 
-| FATIP | Name | Category |
-| ----- | ---- | -------- |
-|       |      |          |
+| FATIP | Name                        | Category       |
+| ----- | --------------------------- | -------------- |
+| 2     | Pegged Asset Token Standard | Token Standard |
 
 
 ## Draft

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ A non-fungible asset token standard.
   - Every token is unique, and can have unique properties
   - Tokens have a history of the addresses they've resided at
 
+### [**FAT-2**](fatips/2.md)
+
+Pegnet: Pegged Asset Token Standard
+
+
+
 
 # Getting Started
 

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -44,7 +44,7 @@ A single Factom chain is defined to house OPR entries depending on test or produ
 
 Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
 
-#### OPR Entry
+#### OPR Challenge & Solution
 
 Each OPR entry must contain an a valid solution to a LXRHash based proof of work problem (challenge) based on the Factom network block height height. For example:
 
@@ -54,7 +54,7 @@ Expected Solution (Prefix?): <PREFIX>
 Winning Answer: <ANSWER>
 ```
 
-The proof of work solution is `<ENCODING>` encoded in the 0th External ID of the OPR entry.
+#### OPR Entry
 
 #####  Content Example & Validation
 
@@ -63,6 +63,7 @@ The proof of work solution is `<ENCODING>` encoded in the 0th External ID of the
     "previous": [
         "6ZeCoXShJ4hdVJNfTvK9azESibUgLxjBGn5ceEU5x3Ae"
     ],
+    "identity": "8888880000000000000000000000000000000000000000000000000000000000",
     "reward": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
     "rates":{
     	"PNT": 0,
@@ -74,17 +75,29 @@ The proof of work solution is `<ENCODING>` encoded in the 0th External ID of the
 }
 ```
 
-| Name       | Type   | Description                                               | Validation                                                   | Required |
-| ---------- | ------ | --------------------------------------------------------- | ------------------------------------------------------------ | -------- |
-| `previous` | array  | Previous winning OPR Factom entry hashes                  | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
-| `reward`   | string | The public Factoid address to credit the mining reward to | Must be a valid public Factoid address.                      | Y        |
-| `rates`    | object | The witnessed exchange rates by the miner                 | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
+| Name       | Type   | Description                                                  | Validation                                                   | Required |
+| ---------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
+| `previous` | array  | Previous winning OPR Factom entry hashes                     | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
+| `identity` | string | The identity chain that produced this OPR result. The entry is signed by this identity | Valid Factom serveridentity or DID chain                     | Y        |
+| `reward`   | string | The public Factoid address to credit the mining reward to    | Must be a valid public Factoid address.                      | Y        |
+| `rates`    | object | The witnessed exchange rates by the miner                    | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
 
-##### External ID Validation
+##### Signing & Extids
+
+OPR Entries implement  [FATIP-103](103.md) to prevent replay attacks, limit, and track OPR answers. As defined by the spec, the first 3 ExtIDS correspond to(please forgive 1 indexing on bullets):
+
+1. The unix timestamp of the OPR entry
+2. The RCD of the signing identity (or DID in the future), corresponding to the `identity` field in the OPR content which defines the identity or DID chain
+3. The signature of the OPR of a salt of, concatenated:
+   1.  The RCD+Signature index (`0` since this is the first)
+   2. The timestamp in ExtID 0
+   3.  The OPR Chain ID the entry is on
+
+The 4th ExtID is the answer to the OPR challenge via LXRHash:
 
 | Index | Description                                                 | Encoding     | Example                                                      |
 | ----- | ----------------------------------------------------------- | ------------ | ------------------------------------------------------------ |
-| 0     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
+| 3     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
 
 
 

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -117,11 +117,18 @@ To be compatible with the pegged asset token standard a FAT-0 token must be issu
 
 Namely, the FAT-0 token must be initialized by the anonymous "system issuer" identity chain `8888880000000000000000000000000000000000000000000000000000000000` which is un-mineable. This signifies that the pegged asset token system has issuer control over the tokens on that standard.
 
-For example, to issue the base PNT token the FAT-0 token will have the following traits:
+For example, to issue the base PNT token the FAT-0 token chain's first entry will have the following traits:
+
+- ExtId 0 - `token`
+
+- ExtId 1 (Token ID) - `PNT`
+
+- ExtId 2 - `issuer`
 
 - ExtId 0 (Issuer ID) - `8888880000000000000000000000000000000000000000000000000000000000`
 
-- ExtId 1 (Token ID) - `PNT`
+  
+
 - Content - Unchanged
 
 

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -38,11 +38,19 @@ Miners submit valid OPR entries to the OPR chain each block in hopes of winning 
 
 A single Factom chain is defined to house OPR entries depending on test or production chains, defined as the chain with hex encoded External IDs in zero-indexed order:
 
-- `5065674e6574` - "Pegnet" in ascii
-- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+##### TestNet
+- `5065674e6574` - "PegNet" in ascii
+- `546573744e6574` - "TestNet" in ascii. 
 - `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
 
 Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
+
+##### MainNet
+- `5065674e6574` - "PegNet" in ascii
+- `4d61696e4e6574` - "MainNet" in ascii. 
+- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+
+Corresponding to chain ID `45b6e921922145e8102912fe3df87a0b658a8b4c3ed0a177885964969d16b989`
 
 #### OPR Challenge & Solution
 
@@ -60,52 +68,70 @@ Winning Answer: <ANSWER>
 
 ```json
 {
-    "previous": [
-        "6ZeCoXShJ4hdVJNfTvK9azESibUgLxjBGn5ceEU5x3Ae"
-    ],
-    "identity": "8888880000000000000000000000000000000000000000000000000000000000",
-    "reward": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
-    "rates":{
-    	"PNT": 0,
-    	"USD": 0,
-    	"EUR": 0,
-    	"JPY": 0,
-    	"FCT": 5.743
-    }
+  "winners": [
+    "ba98d1bc839877a6",
+    "450b0e3cf82c44a1",
+    "d836f7dd1bd35cea",
+    "622999fc9cd69d04",
+    "1445e65cb2950df5",
+    "ccc624f717fd404c",
+    "63ffab6aa79e290d",
+    "261495af94840ccd",
+    "f341e51eb9573352",
+    "e73d7efe8baa5cca"
+  ],
+  "reward": "tPNT_VN4aumDQwQMugTyNXTDbuRgg2jgFyCrwezGkRz7p35tQmJaFx",
+  "identity": [
+    "Minder",
+    "Bob",
+    "99"
+  ],
+  "rates": {
+    "PNT": 0,
+    "USD": 1.0109,
+    "EUR": 0.9147,
+    "JPY": 110.7317,
+    "XBC": 339.839,
+    "FCT": 4.2861
+  }
 }
 ```
 
 | Name       | Type   | Description                                                  | Validation                                                   | Required |
 | ---------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
-| `previous` | array  | Previous winning OPR Factom entry hashes                     | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
-| `identity` | string | The identity chain that produced this OPR result. The entry is signed by this identity | Valid Factom serveridentity or DID chain                     | Y        |
-| `reward`   | string | The public Factoid address to credit the mining reward to    | Must be a valid public Factoid address.                      | Y        |
-| `rates`    | object | The witnessed exchange rates by the miner                    | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
-
-##### Signing & Extids
-
-OPR Entries implement  [FATIP-103](103.md) to prevent replay attacks, limit, and track OPR answers. As defined by the spec, the first 3 ExtIDS correspond to(please forgive 1 indexing on bullets):
-
-1. The unix timestamp of the OPR entry
-2. The RCD of the signing identity (or DID in the future), corresponding to the `identity` field in the OPR content which defines the identity or DID chain
-3. The signature of the OPR of a salt of, concatenated:
-   1.  The RCD+Signature index (`0` since this is the first)
-   2. The timestamp in ExtID 0
-   3.  The OPR Chain ID the entry is on
-
-The 4th ExtID is the answer to the OPR challenge via LXRHash:
-
-| Index | Description                                                 | Encoding     | Example                                                      |
-| ----- | ----------------------------------------------------------- | ------------ | ------------------------------------------------------------ |
-| 3     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
-
+| `previous` | array  | Previous winning OPR Factom short entry hashes                     | Values must be 10 valid entry hashes that correspond to the previous OPR winning entries in order. The genesis OPR has no previous winning entries | Y        |
+| `identity` | string | The identity fields for the Identity Chain ID | To be a Valid DID chain; initially a arbitrary set of fields                      | Y        |
+| `reward`   | string | The public PNT address to credit the mining reward to    | Must be a valid public PNT address.                      | Y        |
+| `rates`    | object | The witnessed exchange rates by the miner                    | Keys must be currency symbols, values must be numbers greater than `0`  (initially the PNT address can be zero) | Y        |
 
 
 #### OPR Grading Algorithm
 
-**NEED MORE INFO HERE**
+To grade, a block must have at least 10 valid OPRs.
+
+With each block, OPRs submitted to the Oracle Price Record chain are graded for the purpose of distributing the 
+block reward.  The highest graded OPR also provides the pricing for the Pegged assets for that block.
+
+[Grading](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#bookmark=id.4nst6v3fi9ki) is done as follows:
+
+* Sort all valid OPR by their difficulty.
+* If less than 10, no OPR records are valid.
+* If more than 50 are valid, take the top 50, and reduce the valid OPRs by repeated passes until only 10 OPR records remain:
+  * Compute the average value for each pegged asset as reported by all 50 OPRs 
+  * For each remaining valid OPR 
+    * Compute the grade for the opr 
+        * For each asset in the OPR
+            * Calculate the difference of that OPR's price from the average price reported by all OPRs
+            * Add to the OPR grade the square of the square of the difference 
+    * Sort OPRs by their grades, and remove the OPR with the highest grade 
+* The final 10 are sorted primary by grade and secondary by proof of work.
 
 
+##### Rewards:
+The best graded 10 OPR records 
+ * Best graded OPR gets 16% (800 PNT)
+ * Second best OPR gets 12% (600 PNT)
+ * All Other OPRs get 9% each (450 PNT)
 
 ### Token Model
 

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -1,0 +1,199 @@
+| FATIP | Title                       | Status | Category       | Author               | Created   |
+| ----- | --------------------------- | ------ | -------------- | -------------------- | --------- |
+| 2     | Pegged Asset Token Standard | WIP    | Token Standard | Pegnet Working Group | 7-17-2019 |
+
+
+
+# Summary
+
+From the [PegNet Whitepaper](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#heading=h.b48un57wbewg):
+
+> PegNet is a Pegged Token Network, and it leverages simple game theory and a set of pegged assets that self reinforce each other.  The network provides a mechanism for managing payments, treasury allocations, and budgets across jurisdictions without requiring expensive and slow processes through external parties such as financial institutions, payment processors, exchanges, etc.  
+
+
+
+# Motivation
+
+From the Pegnet Whitepaper:
+
+> Pegged tokens are generally useful for payments, treasury management, exchanges, and wealth preservation.  A Pegged Token network defines a set of pegged tokens, which reflect real market assets such as currencies, precious metals, other cryptocurrency assets, commodities, etc.  For example, a token pegged to USD can be used to make USD purchases, and both the buyer and seller can be assured of the payment with the pegged value will be very close to equal to the dollar equivalent.  For companies holding cryptocurrency assets, the ability to convert parts of those assets into a dollar peg can help to preserve capital when the cryptocurrency market is low.  
+>
+> [...]
+>
+> Pegging to cryptocurrencies can facilitate transactions representing Bitcoin or other cryptocurrency values without the transaction limitations that might exist on the those  blockchains.  Pegging values to other commodities or assets are possible, expanding the use cases for a Pegged Token Network.
+
+# Specification
+
+### Oracle Price Records (OPR)
+
+The pegged asset token uses Oracle Price Record entries, or OPR's, as the main vehicle for oraclizing and forming consensus on exchange rates. An OPR is composed of several core components:
+
+- An answer to a proof of work question
+- Asset exchange rates as witnessed by the miner
+- A payout address for rewards
+
+Miners submit valid OPR entries to the OPR chain each block in hopes of winning a multi-party proof of work problem that rewards in the base token: PNT.
+
+#### OPR Chain
+
+A single Factom chain is defined to house OPR entries depending on test or production chains, defined as the chain with hex encoded External IDs in zero-indexed order:
+
+- `5065674e6574` - "Pegnet" in ascii
+- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+
+Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
+
+#### OPR Entry
+
+Each OPR entry must contain an a valid solution to a LXRHash based proof of work problem (challenge) based on the Factom network block height height. For example:
+
+```
+Factom Network Height: 3033
+Expected Solution (Prefix?): <PREFIX>
+Winning Answer: <ANSWER>
+```
+
+The proof of work solution is `<ENCODING>` encoded in the 0th External ID of the OPR entry.
+
+#####  Content Example & Validation
+
+```json
+{
+    "previous": [
+        "6ZeCoXShJ4hdVJNfTvK9azESibUgLxjBGn5ceEU5x3Ae"
+    ],
+    "reward": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
+    "rates":{
+    	"PNT": 0,
+    	"USD": 0,
+    	"EUR": 0,
+    	"JPY": 0,
+    	"FCT": 5.743
+    }
+}
+```
+
+| Name       | Type   | Description                                               | Validation                                                   | Required |
+| ---------- | ------ | --------------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| `previous` | array  | Previous winning OPR Factom entry hashes                  | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
+| `reward`   | string | The public Factoid address to credit the mining reward to | Must be a valid public Factoid address.                      | Y        |
+| `rates`    | object | The witnessed exchange rates by the miner                 | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
+
+##### External ID Validation
+
+| Index | Description                                                 | Encoding     | Example                                                      |
+| ----- | ----------------------------------------------------------- | ------------ | ------------------------------------------------------------ |
+| 0     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
+
+
+
+#### OPR Grading Algorithm
+
+**NEED MORE INFO HERE**
+
+
+
+### Token Model
+
+#### FAT-0
+
+The pegged asset token standard uses FAT-0 based tokens to represent pegged assets. Trading of terminal pegged assets from address to address will take place on FAT-0 tokens, while conversions inside an address from pegged asset to pegged asset will take place on the central pegnet chain.
+
+To be compatible with the pegged asset token standard a FAT-0 token must be issued with the parameters laid out in the [FAT-0 Spec](0.md) details on the pegged asset network compatibility section. The Pegnet pair string shall be the token's ID
+
+Namely, the FAT-0 token must be initialized by the anonymous "system issuer" identity chain `8888880000000000000000000000000000000000000000000000000000000000` which is un-mineable. This signifies that the pegged asset token system has issuer control over the tokens on that standard.
+
+For example, to issue the base PNT token the FAT-0 token will have the following traits:
+
+- ExtId 0 (Issuer ID) - `8888880000000000000000000000000000000000000000000000000000000000`
+
+- ExtId 1 (Token ID) - `PNT`
+- Content - Unchanged
+
+
+
+### Conversions
+
+Conversions represent a specialized type of transaction that atomically converts one terminal pegged FAT-0 asset into another at the current OPR based exchange rate. Conversions happen inside an address and do not transact tokens between peers.
+
+#### Conversion Chain
+
+Each pegged network shall have it's own conversion chain, defined using the same network string as the OPR chain. For example, the Testnet conversion chain is defined as the following hex encoded External IDs:
+
+- `5065674e6574` - "Pegnet" in ascii
+- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+- `436F6E76657273696F6E73` - "Conversions" in ascii
+
+#### Conversion Entry
+
+##### Content Example & Validation
+
+```json
+{
+	"address": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
+    "from": "PNT",
+    "to": "FCT",
+    "amount": 10.021,
+    "metadata": "I want Factom!"
+}
+```
+
+| Name       | Type   | Description                                               | Validation                                            | Required |
+| ---------- | ------ | --------------------------------------------------------- | ----------------------------------------------------- | -------- |
+| `address`  | string | The Public Factoid address to convert pegged tokens on    | Must be a valid public Factoid address                | Y        |
+| `from`     | string | The pegged asset token ID to convert from                 | Must correspond to a valid issued pegged FAT-0 token  | Y        |
+| `to`       | string | The pegged asset token ID to convert to from `from`       | Must correspond to a valid issued pegged FAT-0 token` | Y        |
+| `amount`   | number | The amount of `from` to use as an input to the conversion | Must be greater than `0`                              | Y        |
+| `metadata` | any    | Arbitrary user defined metadata for the conversion        | Must be valid JSON                                    | N        |
+
+##### Implicit Base Token Conversion
+
+The pegged asset token uses the PNT base token to describe exchange rates. Since all conversions are in ratio of the base token, a conversion using `from` equal to FCT and `to` equal to USD have an implicit conversion to PNT as an intermediary at the current OPR exchange rate.
+
+##### Signing
+
+Conversions are signed according to [FATIP-103](103.md). The signing set is
+the key corresponding to `address` field. The conversion must include an RCD/Signature pair for the source address of the conversion. Signatures and RCDs are defined in the External IDs of the conversion entry as laid out in FATIP-103.
+
+#### Conversion Validation
+
+Conversions must meet all of the following criteria to be valid.
+
+General Criteria:
+
+- The content of the entry must be a single well-formed JSON.
+- The JSON must contain all required fields listed in the above table, all fields and their members must be of the correct type. No unspecified fields may be present. No duplicate field names are allowed.
+- The entry hash of the conversion entry must be unique among all
+  previously valid conversions of the pegged asset token.
+- The External IDs must follow the cryptographic and structural
+  requirements defined by [FATIP-103](103.md) for the `address` input
+
+Specific Criteria:
+
+- Pegged token `from` must exist and be issued
+- Pegged token `to` must exist and be issued
+- `address` must own at least `amount` of pegged token `from` for the conversion to be valid
+
+
+
+If all criteria is met, the following occurs as a single atomic operation:
+
+- `amount` of token `from` is burnt (destroyed) in address `address`
+- `from` is converted to PNT (interim) at the OPR exchange rate
+- Interim PNT is expended to create `to`  via coinbase transaction at the OPR exchange rate
+
+The conversion is complete.
+
+
+
+# Implementation
+
+[Pegnet Project](https://github.com/pegnet/pegnet)
+
+
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Updated the specification to fit the miner use case, and to remove references to signed entries as they are not needed.
Other updates and fixes.

The address question is still critical and needs to be addressed.