### PR TITLE
FATIP-2 Update to Pegged Asset Token Standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore common artifacts of editing
+#
+# Binaries for programs and plugins, merges, tools
+*.idea
+*.dat
+*.orig
+*.txt
+
+# Goland
+.idea/*

--- a/fatips/2.md
+++ b/fatips/2.md
@@ -38,11 +38,19 @@ Miners submit valid OPR entries to the OPR chain each block in hopes of winning 
 
 A single Factom chain is defined to house OPR entries depending on test or production chains, defined as the chain with hex encoded External IDs in zero-indexed order:
 
-- `5065674e6574` - "Pegnet" in ascii
-- `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
+##### TestNet
+- `5065674e6574` - "PegNet" in ascii
+- `546573744e6574` - "TestNet" in ascii. 
 - `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
 
 Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
+
+##### MainNet
+- `5065674e6574` - "PegNet" in ascii
+- `4d61696e4e6574` - "MainNet" in ascii. 
+- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+
+Corresponding to chain ID `45b6e921922145e8102912fe3df87a0b658a8b4c3ed0a177885964969d16b989`
 
 #### OPR Challenge & Solution
 
@@ -60,52 +68,70 @@ Winning Answer: <ANSWER>
 
 ```json
 {
-    "previous": [
-        "6ZeCoXShJ4hdVJNfTvK9azESibUgLxjBGn5ceEU5x3Ae"
-    ],
-    "identity": "8888880000000000000000000000000000000000000000000000000000000000",
-    "reward": "FA1zT4aFpEvcnPqPCigB3fvGu4Q4mTXY22iiuV69DqE1pNhdF2MC",
-    "rates":{
-    	"PNT": 0,
-    	"USD": 0,
-    	"EUR": 0,
-    	"JPY": 0,
-    	"FCT": 5.743
-    }
+  "winners": [
+    "ba98d1bc839877a6",
+    "450b0e3cf82c44a1",
+    "d836f7dd1bd35cea",
+    "622999fc9cd69d04",
+    "1445e65cb2950df5",
+    "ccc624f717fd404c",
+    "63ffab6aa79e290d",
+    "261495af94840ccd",
+    "f341e51eb9573352",
+    "e73d7efe8baa5cca"
+  ],
+  "reward": "tPNT_VN4aumDQwQMugTyNXTDbuRgg2jgFyCrwezGkRz7p35tQmJaFx",
+  "identity": [
+    "Minder",
+    "Bob",
+    "99"
+  ],
+  "rates": {
+    "PNT": 0,
+    "USD": 1.0109,
+    "EUR": 0.9147,
+    "JPY": 110.7317,
+    "XBC": 339.839,
+    "FCT": 4.2861
+  }
 }
 ```
 
 | Name       | Type   | Description                                                  | Validation                                                   | Required |
 | ---------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
-| `previous` | array  | Previous winning OPR Factom entry hashes                     | Values must be valid entry hashes that correspond to OPR entries. Can be 0 elements in length | Y        |
-| `identity` | string | The identity chain that produced this OPR result. The entry is signed by this identity | Valid Factom serveridentity or DID chain                     | Y        |
-| `reward`   | string | The public Factoid address to credit the mining reward to    | Must be a valid public Factoid address.                      | Y        |
-| `rates`    | object | The witnessed exchange rates by the miner                    | Keys must be currency symbols, values must be numbers greater than or equal to `0` | N        |
-
-##### Signing & Extids
-
-OPR Entries implement  [FATIP-103](103.md) to prevent replay attacks, limit, and track OPR answers. As defined by the spec, the first 3 ExtIDS correspond to(please forgive 1 indexing on bullets):
-
-1. The unix timestamp of the OPR entry
-2. The RCD of the signing identity (or DID in the future), corresponding to the `identity` field in the OPR content which defines the identity or DID chain
-3. The signature of the OPR of a salt of, concatenated:
-   1.  The RCD+Signature index (`0` since this is the first)
-   2. The timestamp in ExtID 0
-   3.  The OPR Chain ID the entry is on
-
-The 4th ExtID is the answer to the OPR challenge via LXRHash:
-
-| Index | Description                                                 | Encoding     | Example                                                      |
-| ----- | ----------------------------------------------------------- | ------------ | ------------------------------------------------------------ |
-| 3     | The solution to the OPR challenge at current network height | `<ENCODING>` | `ac9c7600006b7fc01f422e38cfde7ee9e441fe918418578406e6ad39ce867301` |
-
+| `previous` | array  | Previous winning OPR Factom short entry hashes                     | Values must be 10 valid entry hashes that correspond to the previous OPR winning entries in order. The genesis OPR has no previous winning entries | Y        |
+| `identity` | string | The identity fields for the Identity Chain ID | To be a Valid DID chain; initially a arbitrary set of fields                      | Y        |
+| `reward`   | string | The public PNT address to credit the mining reward to    | Must be a valid public PNT address.                      | Y        |
+| `rates`    | object | The witnessed exchange rates by the miner                    | Keys must be currency symbols, values must be numbers greater than `0`  (initially the PNT address can be zero) | Y        |
 
 
 #### OPR Grading Algorithm
 
-**NEED MORE INFO HERE**
+To grade, a block must have at least 10 valid OPRs.
+
+With each block, OPRs submitted to the Oracle Price Record chain are graded for the purpose of distributing the 
+block reward.  The highest graded OPR also provides the pricing for the Pegged assets for that block.
+
+[Grading](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#bookmark=id.4nst6v3fi9ki) is done as follows:
+
+* Sort all valid OPR by their difficulty.
+* If less than 10, no OPR records are valid.
+* If more than 50 are valid, take the top 50, and reduce the valid OPRs by repeated passes until only 10 OPR records remain:
+  * Compute the average value for each pegged asset as reported by all 50 OPRs 
+  * For each remaining valid OPR 
+    * Compute the grade for the opr 
+        * For each asset in the OPR
+            * Calculate the difference of that OPR's price from the average price reported by all OPRs
+            * Add to the OPR grade the square of the square of the difference 
+    * Sort OPRs by their grades, and remove the OPR with the highest grade 
+* The final 10 are sorted primary by grade and secondary by proof of work.
 
 
+##### Rewards:
+The best graded 10 OPR records 
+ * Best graded OPR gets 16% (800 PNT)
+ * Second best OPR gets 12% (600 PNT)
+ * All Other OPRs get 9% each (450 PNT)
 
 ### Token Model
 


### PR DESCRIPTION
Added a .gitignore for artifacts that development tools often generate
Fixed errors of hex to ascii in chain names
Updated the winners to be required 10 (exception is the genesis OPR) and to short hashes in hex (for easier review by miners)
Reward is a PNT address (with the caveat that we can make it a tagged address)

Removed signing and identity dependency -- we don't need this because of the previous winners lock entries into a block (so they cannot be replayed) and Proof of Work and grading establishes who should be paid.

Added grading algorithm from the whitepaper.