### PR TITLE
FATIP-0 Enable Zero Input Transactions & Send to Self

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -184,8 +184,8 @@ and so are ignored to prevent replay attacks.
 
 | Name      | Type   | Description                           | Validation                                                   | Required |
 | --------- | ------ | ------------------------------------- | ------------------------------------------------------------ | -------- |
-| `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
-| `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
+| `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses. | Y        |
+| `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
 | `metadata` | any    | Optional metadata defined by user        | This may be any valid JSON type.                                                     | N        |
 
 For a Transaction to be well-formed it must follow the above defined structure


### PR DESCRIPTION
Currently FAT-0 does not allow sending a zero input/output transaction. This is a useful feature for proving ownership of an address without needing to transact any tokens. This comes up in the context of future smart contract support where the idea is to sign over control of an address to a contract. 

As long as no previous transactions matching this criteria exist the change would be backwards compatible.

As a secondary discussion, the idea of enabling send-to-self transactions where the same address can appear in both `inputs` and `outputs` is being addressed. Currently this is not required, as the proposed mechanism being to send a 0 input & output burn transaction from the target address fulfills the basic feature requirement for future smart contract support. However, it's worth considering use cases in advance so we don't regret it later when we find we needed it all along.

Work should continue on the FAT-0 spec until we finalize a strategy, then be folded over into the FAT-1 spec.

See FAT Discord #standards-discussion thread date 7/23/2019 1:52 PST onwards for discussion