### PR TITLE
FATIP-2 Grammar and Clarification

### DIFF
--- a/fatips/2.md
+++ b/fatips/2.md
@@ -8,7 +8,7 @@
 
 From the [PegNet Whitepaper](https://docs.google.com/document/d/1yv1UaOXjJLEYOvPUT_a8RowRqPX_ofBTJuPHmq6mQGQ/edit#heading=h.b48un57wbewg):
 
-> PegNet is a Pegged Token Network, and it leverages simple game theory and a set of pegged assets that self reinforce each other.  The network provides a mechanism for managing payments, treasury allocations, and budgets across jurisdictions without requiring expensive and slow processes through external parties such as financial institutions, payment processors, exchanges, etc.  
+> PegNet is a Pegged Token Network that leverages simple game theory to create a set of pegged assets that reinforce each other.  The network provides a mechanism for managing payments, treasury allocations, and budgets across jurisdictions without requiring expensive and slow processes through external parties such as financial institutions, payment processors, exchanges, etc.  
 
 
 
@@ -26,9 +26,9 @@ From the Pegnet Whitepaper:
 
 ### Token Model
 
-The pegged asset token standard ("Pegnet") describes a interconnected ecosystem of pegged fungible tokens. Pegged tokens are atomically convertable to eachother at the current OPR exchange rate as determined by the OPR grading algorithm.
+The pegged asset token standard ("Pegnet") describes an interconnected ecosystem of pegged fungible tokens. Pegged tokens are atomically convertible to each other at exchange rates determined for that block by the OPR grading algorithm.
 
-Pegged tokens are "virtual" in nature, as opposed to regular FAT-0 tokens which have their own issuances and chains. Pegged tokens have no dedicated chain or issuance datastructure as they have no issuers. Pegnet token balances are calculated solely on a combination of OPR and Conversion Transaction records.
+Pegged tokens are "virtual" in nature, as opposed to regular FAT-0 tokens which have their own issuances and chains. Pegged tokens have no dedicated chain or issuance datastructure as they have no issuers. Pegnet token balances are calculated using a combination of mined OPRs, transactions, conversions, and burning of FCT.
 
 
 
@@ -59,24 +59,24 @@ Pegged asset onramps are necessary to inject value into the pegged asset token s
 
 #### Factom
 
-Creation of pegged Factom ("pFCT") tokens is described by conducting an 1 Entry Credit purchase on the host Factom network to the following addresses to fund the respective virtual Pegnet networks:
+Creation of pegged Factom ("pFCT") tokens is described by conducting a 1 Entry Credit purchase on the host Factom network to the following addresses to fund the respective virtual Pegnet networks:
 
-- Testnet - `EC1moooFCT2TESToooo1oooo1oooo1oooo1oooo1oooo1oooo1oo`
-- Mainnet - `EC1moooFCT2MAINoooo1oooo1oooo1oooo1oooo1oooo1oooo1oo`
+- TestNet - `EC1moooFCT2TESToooo1oooo1oooo1oooo1oooo1oooo1oooo1oo`
+- MainNet - `EC1moooFCT2MAINoooo1oooo1oooo1oooo1oooo1oooo1oooo1oo`
 
-The additional fees of the EC purchase transaction over the base network fee describe the quantity of pFCT credited to the purchasing Factoid address on the pegged asset token system.
+The additional fees of the EC purchase transaction over the base network fee describe the quantity of pFCT credited to the purchasing Factoid address on the pegged asset token system at the rate set by the winning OPR for that block.
 
 
 
 ### Oracle Price Records (OPR)
 
-The pegged asset token system uses Oracle Price Record entries, or OPR's, as the main vehicle for oraclizing and forming consensus on exchange rates. An OPR is composed of several core components:
+The pegged asset token system uses Oracle Price Record entries, or OPRs, as the main vehicle for oraclizing and forming consensus on exchange rates. An OPR is composed of several core components:
 
 - An answer to a proof of work question
-- Asset exchange rates as witnessed by the miner
+- Asset exchange rates, relative to USD, as witnessed by the miner
 - A payout address for rewards
 
-Miners submit valid OPR entries to the OPR chain each block in hopes of winning a competitive proof of work problem against other miners that rewards in the base token: PNT.
+Miners submit valid OPRs to the OPR chain each block in hopes of winning a competitive proof of work problem against other miners that rewards in the base token: PNT.
 
 #### OPR Chain
 
@@ -85,20 +85,20 @@ A single Factom chain is defined to house OPR entries depending on test or produ
 ##### TestNet
 - `5065674e6574` - "PegNet" in ascii
 - `546573744e6574` - "TestNet" in ascii. 
-- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+- `4f7261636c6550726963655265636f726473` - "OraclePriceRecords" in ascii
 
-Corresponding to chain ID `b312a0401879366b3d72a1844b3ca0da1009545ffa8e4038f80da1528cb572ab`
+Corresponding to chain ID `fafedb5fb8e7d1512244b683608f0b248326f1b8fae497058ba8ae8d577e9c14`
 
 ##### MainNet
 - `5065674e6574` - "PegNet" in ascii
 - `4d61696e4e6574` - "MainNet" in ascii. 
-- `4f7261636c65205072696365205265636f726473` - "Oracle Price Records" in ascii
+- `4f7261636c6550726963655265636f726473` - "OraclePriceRecords" in ascii
 
-Corresponding to chain ID `45b6e921922145e8102912fe3df87a0b658a8b4c3ed0a177885964969d16b989`
+Corresponding to chain ID `a642a8674f46696cc47fdb6b65f9c87b2a19c5ea8123b3d2f0c13b6f33a9d5ef`
 
-#### OPR Challenge & Solution
+#### OPR Proof of Work Calculation
 
-Each OPR entry must contain an a valid solution to a LXRHash based proof of work problem (challenge) based on the Factom network block height height. For example:
+Each OPR contains a set bytes in ExtId[0] called the nonce. To evaluate the proof of work result ("difficulty"), the Grading algorithm takes the LXR-Hash of the entry's content, appends it with the nonce, and LXR-Hashes it again. The first 8 bytes of the resulting hash are converted to an unsigned 64 bit integer in Big Endian order. A higher value is considered a better difficulty, with 0 being the worst and `2^64 - 1` being the best.
 
 ```
 TODO: NEED HEIGHT-CHALLENGE-SOLUTION EXAMPLE
@@ -181,9 +181,13 @@ The best graded 10 OPR records
 
 Conversions represent a specialized type of transaction that atomically converts one terminal pegged FAT-0 asset into another at the current OPR based exchange rate. Conversions may also move tokens between addresses without conversion.
 
+#### Conversion Rate
+
+All conversions use the exchange rate defined in the OPR with the highest grade inside that block. If a conversion is written to a block that has no winners, the conversions are evaluated using the highest grade of the following block with winners.
+
 #### Conversion Transaction Chain
 
-Each pegged network shall have it's own conversion chain, defined using the same network string as the OPR chain. For example, the Testnet conversion chain is defined as the following hex encoded External IDs:
+Each pegged network shall have its own conversion chain, defined using the same network string as the OPR chain. For example, the Testnet conversion chain is defined as the following hex encoded External IDs:
 
 - `5065674e6574` - "Pegnet" in ascii
 - `546573744e6574` - "Testnet" in ascii. Can be "Mainnet" for production
@@ -214,10 +218,6 @@ Each pegged network shall have it's own conversion chain, defined using the same
 | `amount`   | number  | The amount of `from` to use as an input to the conversion    | Must be greater than `0`                            | Y        |
 | `origin`   | boolean | Whether to apply `amount` as the input amount of the conversion. `amount` is applied as the conversion output amount of `to` by default. | Valid boolean. May be omitted for default behavior. | N        |
 | `metadata` | any     | Arbitrary user defined metadata for the conversion           | Must be valid JSON                                  | N        |
-
-##### Implicit Base Token Conversion
-
-The pegged asset token uses the PNT base token to describe exchange rates. Since all conversions are in ratio of the base token, a conversion using `from` equal to FCT and `to` equal to USD have an implicit conversion to PNT as an intermediary at the current OPR exchange rate.
 
 ##### Signing
 


### PR DESCRIPTION
* Fixed some minor grammatical issues
* the section on "Implicit conversions" was wrong, it doesn't happen this way
* updated the chain names to align with https://github.com/pegnet/pegnet/pull/116
tagging #25 so it shows up there