### PR TITLE
FATIP-0 Precision

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -135,11 +135,11 @@ valid one, are always considered invalid and ignored.
 
 | Name        | Type   | Description                                                  | Validation                                                   | Required |
 | ----------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
-| `type`      | string | The type of this token issuance                              | Must equal 'FAT-0'                                           | Y        |
-| `supply`    | number | The maximum possible number of tokens that can ever be issued | Must be greater than 0, or -1 for an unlimited supply. All other values are invalid. | Y        |
-| `precision` | number | The decimal accuracy of the tokens base unit (e.g. each 1 EXT is composed of 10 ^ `precision` base units) | Must be an integer in the range 0-18 inclusive. Default 0    | N        |
-| `symbol`    | string | The display symbol of the token                              | Must be A-Z, and 1-4 characters in length                    | N        |
-| `metadata`  | any    | Optional metadata defined by the Issuer                      | This may be any valid JSON type.                             | N        |
+| `type`      | string | The type of this token issuance.                             | Must equal 'FAT-0'.                                          | Y        |
+| `supply`    | number | The maximum possible number of tokens that can ever be issued. | Must be greater than 0, or -1 for an unlimited supply. All other values are invalid. | Y        |
+| `precision` | number | The decimal accuracy of the tokens base unit (e.g. each 1 EXT is composed of 10 ^ `precision` base units). | Must be an integer in the range 0-18 inclusive. Default 0.   | N        |
+| `symbol`    | string | The display symbol of the token.                             | Must be A-Z, and 1-4 characters in length.                   | N        |
+| `metadata`  | any    | Optional metadata defined by the Issuer.                     | This may be any valid JSON type.                             | N        |
 
 ### Signing
 
@@ -186,9 +186,9 @@ and so are ignored to prevent replay attacks.
 
 | Name      | Type   | Description                           | Validation                                                   | Required |
 | --------- | ------ | ------------------------------------- | ------------------------------------------------------------ | -------- |
-| `inputs`  | object | The inputs of the transaction   | Mapping of input Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
-| `outputs` | object | The outputs of the transaction       | Mapping of output Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
-| `metadata` | any    | Optional metadata defined by user        | This may be any valid JSON type.                                                     | N        |
+| `inputs`  | object | The inputs of the transaction.  | Mapping of input Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
+| `outputs` | object | The outputs of the transaction.      | Mapping of output Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
+| `metadata` | any    | Optional metadata defined by user.       | This may be any valid JSON type.                                                    | N        |
 
 For a Transaction to be well-formed it must follow the above defined structure
 with all required fields. Additionally, the token amounts must be conserved.

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -137,7 +137,7 @@ valid one, are always considered invalid and ignored.
 | ----------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
 | `type`      | string | The type of this token issuance.                             | Must equal 'FAT-0'.                                          | Y        |
 | `supply`    | number | The maximum possible number of tokens that can ever be issued. | Must be greater than 0, or -1 for an unlimited supply. All other values are invalid. | Y        |
-| `precision` | number | The decimal accuracy of the tokens base unit (e.g. each 1 EXT is composed of 10 ^ `precision` base units). | Must be an integer in the range 0-18 inclusive. Default 0.   | N        |
+| `precision` | number | The decimal accuracy of the tokens base unit (e.g. each 1 EXT is composed of 10 ^ 5 base units). | Must be an integer in the range 0-18 inclusive. Default 0.   | N        |
 | `symbol`    | string | The display symbol of the token.                             | Must be A-Z, and 1-4 characters in length.                   | N        |
 | `metadata`  | any    | Optional metadata defined by the Issuer.                     | This may be any valid JSON type.                             | N        |
 

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -125,6 +125,7 @@ valid one, are always considered invalid and ignored.
 {
   "type": "FAT-0",
   "supply": 10000000,
+  "precision": 5, 
   "symbol": "EXT",
   "metadata": {"custom-field": "example"}
 }
@@ -132,12 +133,13 @@ valid one, are always considered invalid and ignored.
 
 ### Initialization Entry Field Summary & Validation
 
-| Name       | Type   | Description                                                   | Validation                                                                           | Required |
-| ---------- | ------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
-| `type`     | string | The type of this token issuance                               | Must equal 'FAT-0'                                                                   | Y        |
-| `supply`   | number | The maximum possible number of tokens that can ever be issued | Must be greater than 0, or -1 for an unlimited supply. All other values are invalid. | Y        |
-| `symbol`   | string | The display symbol of the token                               | Must be A-Z, and 1-4 characters in length                                            | N        |
-| `metadata` | any    | Optional metadata defined by the Issuer                       | This may be any valid JSON type.                                                     | N        |
+| Name        | Type   | Description                                                  | Validation                                                   | Required |
+| ----------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
+| `type`      | string | The type of this token issuance                              | Must equal 'FAT-0'                                           | Y        |
+| `supply`    | number | The maximum possible number of tokens that can ever be issued | Must be greater than 0, or -1 for an unlimited supply. All other values are invalid. | Y        |
+| `precision` | number | The decimal accuracy of the tokens base unit (e.g. each 1 EXT is composed of 10 ^ `precision` base units) | Must be an integer in the range 0-18 inclusive. Default 0    | N        |
+| `symbol`    | string | The display symbol of the token                              | Must be A-Z, and 1-4 characters in length                    | N        |
+| `metadata`  | any    | Optional metadata defined by the Issuer                      | This may be any valid JSON type.                             | N        |
 
 ### Signing
 
@@ -184,8 +186,8 @@ and so are ignored to prevent replay attacks.
 
 | Name      | Type   | Description                           | Validation                                                   | Required |
 | --------- | ------ | ------------------------------------- | ------------------------------------------------------------ | -------- |
-| `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
-| `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
+| `inputs`  | object | The inputs of the transaction   | Mapping of input Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
+| `outputs` | object | The outputs of the transaction       | Mapping of output Public Factoid Address => Amount of base units. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
 | `metadata` | any    | Optional metadata defined by user        | This may be any valid JSON type.                                                     | N        |
 
 For a Transaction to be well-formed it must follow the above defined structure


### PR DESCRIPTION
Enable to specifying the number of "base units" that make up one whole fungible token. This is important for token systems that require a decimal system. Currently precision is only calculated and enforced at the application level, however, it would be useful to specify immutably in the protocol so it can be used in wallets and the like.

This is a backwards compatible change for currently issued FAT-0 tokens. Precision is an optional field. Currently issued tokens are assumed to have a precision of 0 (1 base unit per whole unit, AKA a "fungible non-fungible token").

For example, a precision of 3 would mean that 3 decimal places are supported: There are 1000 base units per whole unit. A maximum value of 18 is proposed to match the de facto ERC-20 standard maximum precision.