### PR TITLE
FATIP-S Smart Contracts and Supporting Standards

### DIFF
--- a/fatips/0.md
+++ b/fatips/0.md
@@ -186,6 +186,11 @@ and so are ignored to prevent replay attacks.
 | --------- | ------ | ------------------------------------- | ------------------------------------------------------------ | -------- |
 | `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses. | Y        |
 | `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
+|  |  |  |  |  |
+| `contract` | string | The contract publication chain to use to establish a contract at output address 0 | Valid Factom chain ID. Valid [FATIP-104](104.md) contract chain. May not be specified alongside `func` or `args`. See [Contract Publication Transactions](#Contract-Publication-Transactions). | N |
+| `func` | string | The full function name to call | Function must exist in the ABI of the contract at `contract`. Must be specified with `args`. See [Contract Call Transactions](#Contract-Call-Transactions). | N |
+| `args` | array | The array of arguments to call `func` with | Arguments must comply with the function signature argument types specified in the ABI at `contract`. Must be specified with `func`. See [Contract Call Transactions](#Contract-Call-Transactions). | N |
+|  |  |  |  |  |
 | `metadata` | any    | Optional metadata defined by user        | This may be any valid JSON type.                                                     | N        |
 
 For a Transaction to be well-formed it must follow the above defined structure
@@ -246,6 +251,22 @@ described above, but with the Coinbase Address as the sole input in the
 output addresses may not intersect. Thus a Coinbase Transaction may not
 directly burn the tokens it issues.
 
+### Contract Publication Transactions
+
+Contract Publication Transactions are transactions that establish a WASM based smart contract at a given Factoid address. Establishing a contract at an address removes the address from human control and delegates control of the address to the contracts code.
+
+Contract publication transactions are identified by a zero-input zero-output transaction from the desired contract address to the burn address, while specifying the `contract` key value pair in the Transaction JSON. The `contract` field specifies the [FATIP-104](104.md) contract chain to use at the address.
+
+An address may hold a balance of FAT-0 tokens before having a contract established, allowing contracts to have a starting balance.
+
+### Contract Call Transactions
+
+Contract Call Transactions are transactions that call a specific function with given arguments inside of a contract established at an address. The field `func` and `args` are used to carry the intended function to call and the arguments to call it with.
+
+To call a contract, a single-input single-output transaction is constructed with the output being the contract Factoid address and `func` & `args` in the main JSON body. A nonzero amount of FAT-0 tokens may be sent in the transaction to denote a fee or other use of tokens.
+
+Normal transactions may be sent to a contract address without `func` & `args` to deposit tokens to the contract address.
+
 #### Coinbase Signing Set
 
 A signature from the current key establised by the Issuer's Identity key is
@@ -292,7 +313,7 @@ Normal transactions must meet all T.x and N.x requirements.
   [FATIP-103](103.md). No additional RCD/Signature pairs beyond those that
   correspond with an input may be included.
 
-### C.x Requirements for Coinbase distribution transactions
+### C.x Requirements for Coinbase transactions
 
 Coinbase transactions must meet all T.x and C.x requirements.
 
@@ -303,17 +324,38 @@ Issuance entry (if not unlimited).
 - C.3.1: The entry must be signed by the Issuer's currently established key in
   the Identity chain according to [FATIP-101](101.md) and [FATIP-103](103.md).
 
+### CP.x Requirements for Contract Publication Transactions
+
+Contract Publication Transactions must meet all T.x and CP.x requirements.
+
+- The target address must be the only input
+- The burn address must be the only output
+- The sum of all amounts must equal zero
+- The target address may not already have a contract established on it
+- The contract at `contract` must pass all validation, `func` and `args` may not be specified
+
+### CC.x Requirements for Contract Call Transactions
+
+Contract Publication Transactions must meet all T.x and CC.x requirements.
+
+- The calling address must be the only input
+- The target address must be the only output
+- The target address must already have a contract established on it
+- The `func` and `args` field must be present and pass validation. The `func` and `args` submitted must match and comply with the function signature of `func`'s `args` specified in the contract ABI.
+
+
+
 ## Computing the Current State
 
 Implementations must maintain the state of the balances of all addresses in
 order to evaluate the validity of a transaction. The current state can be built
 by iterating through all entries in the token chain in chronological order and updating the state for any valid transaction.
 
+Additionally, implementations must maintain the state of contracts and their calls, which are conducted by FAT transactions and may affect the balances of their host token. Contracts have the ability to send, receive, and burn their host FAT tokens. Each contract call results in a return value from the function and arguments submitted, which is then persisted in the state of the contract and linked to the transaction. Thus, the result of a contract call is obtained and identified by it's transaction entryhash.
+
 The following pseudo code describes how to compute the current state of all
 balances. A transaction must be applied entirely or not at all. Entries that
-are not valid transactions are simply ignored. Transactions must be evaluated
-in the order that they appear in the token chain. This assumes the token has
-already been properly initialized.
+are not valid transactions are simply ignored. Contract call results, including errors stemming from Contract Call Transactions are independent of transaction validity, and are persisted in the implementation for later retrieval.  Transactions must be evaluated in the order that they appear in the token chain. This assumes the token has already been properly initialized.
 
 ```
 for entry in token_chain.entries:
@@ -321,8 +363,14 @@ for entry in token_chain.entries:
         if !entry.is_coinbase_transaction():
             for input in entry.inputs:
                 balances[input.address] -= input.amount
-        for output in entry.outputs:
-            balances[output.address] += output.amount
+        	for output in entry.outputs:
+            	balances[output.address] += output.amount
+        else balances[entry.outputs[0]] += output.amount 
+        
+        if entry.is_contract_call():
+        	transaction.result = token_chain.contracts[entry.inputs[0]][func](args...)
+        else if entry.is_contract_publication():
+        	token_chain.contracts[entry.inputs[0]] = entry.contract
 ```
 
 # Implementation

--- a/fatips/0.md
+++ b/fatips/0.md
@@ -184,8 +184,8 @@ and so are ignored to prevent replay attacks.
 
 | Name      | Type   | Description                           | Validation                                                   | Required |
 | --------- | ------ | ------------------------------------- | ------------------------------------------------------------ | -------- |
-| `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses. | Y        |
-| `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be a positive integer. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
+| `inputs`  | object | The inputs of the transaction   | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses. | Y        |
+| `outputs` | object | The outputs of the transaction       | Mapping of Public Factoid Address => Amount. Amount must be am integer greater than or equal to zero. May not be empty or contain duplicate Addresses or any Addresses used in the `inputs`. Sum of the Amounts must equal the sum of the `inputs` Amounts. | Y        |
 | `metadata` | any    | Optional metadata defined by user        | This may be any valid JSON type.                                                     | N        |
 
 For a Transaction to be well-formed it must follow the above defined structure

--- a/fatips/104.md
+++ b/fatips/104.md
@@ -1,0 +1,126 @@
+| FATIP | Title                         | Status | Category | Author                            | Created   |
+| ----- | ----------------------------- | ------ | -------- | --------------------------------- | --------- |
+| 104   | Contract Publication Standard | WIP    | Core     | Devon Katz\<<devonk@dbgrow.com>\> | 9-16-2019 |
+
+
+
+# Summary
+
+This standard describes a method of publishing WebAssembly(WASM) bytecode to a Factom chain. This standard is used in conjunction with specialized FATIP-0 transactions to specify and establish contracts at Factoid addresses. Contracts resolve to a unique Factom Chain Id.
+
+# Motivation
+
+Our [proof of concept](https://github.com/Factom-Asset-Tokens/wasm-contract-poc) successfully demonstrated that raw WASM bytecode could successfully be stored published and interpreted from the External Ids of Factom entry. While effective, this simple system created a hard limit of 10KB in contract size as it used a single entry.
+
+This standard provides a simple method to publish contract bytecode, or more generically any byte buffer to Factom using sequential entries in on a dedicated chain.
+
+Allowing contract code to have a dedicated chain allows reuse of established and vetted contracts. For example, an escrow contract established by a law firm could be implemented directly by multiple different FAT tokens & contracts at their addresses by specifying the chain Id of the contracts compiled source code.
+
+# Specification
+
+## Publication Chain
+
+A single Factom chain is used to hold all of the data about the contract.
+
+## Initial Publication Entry
+
+The initial entry in the publication chain describes and sums up the contents and interface for the contract that will occur in the following entries. It's important to ensure the contract buffer is properly interpreted from the entries in its entirety, otherwise is deemed invalid.
+
+Note that the contracts content determines it's unique Factom chain ID.
+
+### Initial Publication Entry Content Example
+
+```json
+{
+  "bytes": 999,
+  "abi":{
+      "_add":{
+          "args":[
+              "number",
+              "number"
+          ],
+          "returns":"number"
+      }
+  }
+  "metadata": {"contract-name": "example contract"}
+}
+```
+
+
+
+### Initial Publication Entry Field Summary & Validation
+
+| Name             | Type   | Description                                                  | Validation                                                   | Required |
+| ---------------- | ------ | ------------------------------------------------------------ | ------------------------------------------------------------ | -------- |
+| `bytes`          | number | The number of bytes to expect in the contract buffer         | Must be greater than equal to 1                              | Y        |
+| `abi`            | object | The Application Binary Interface(ABI) object that describes the contracts function signatures and return types. Keys in this object are function names. | Valid object                                                 | Y        |
+| `abi[*].args`    | array  | The ordered array of argument types that the function signature accepts. | All elements  must be strings. Must be one of the [Supported Argument And Return Types](#Supported-Arguments-and-Return-Types) | Y        |
+| `abi[*].returns` | string | The type of return value to expect from the function         | Must be a string. Must be one of the [Supported Argument And Return Types](#Supported-Arguments-and-Return-Types) | Y        |
+|                  |        |                                                              |                                                              |          |
+|                  |        |                                                              |                                                              |          |
+| `metadata`       | any    | User defined metadata for the file                           | Must be JSON stringifyable                                   | N        |
+|                  |        |                                                              |                                                              |          |
+
+### Initial Publication Entry External Ids
+
+| Index | Description                                                  | Encoding | Validation                                 | Required |
+| ----- | ------------------------------------------------------------ | -------- | ------------------------------------------ | -------- |
+| 0     | The first `10K - 64 - Content Byte Length`  Bytes of the buffer. | raw      | Must not be greater than `bytes` in length | Y        |
+| 1     | The 64 Byte sha512 output of the full buffer                 | raw      | 64 Bytes in length                         | N        |
+|       |                                                              |          |                                            |          |
+
+### Application Binary Interface
+
+The ABI is a datastructure that defines how the higher level smart contract platform interfaces with the low level binary WASM code. At it's heart a WASM VM is a very low level machine which needs help understanding how to interpret more complex types like strings from the host environment, and vice versa.
+
+#### Supported Arguments and Return Types
+
+- `i32` - 32 Bit integer
+- `i64` - 64 Bit integer
+- `f32` - 32 Bit float
+- `f64` - 64 Bit float
+- `string` - `i32` pointer to an array of null terminated character bytes in linear memory
+- `array[i32]` -  `i32` pointer to an array of `i32` bytes in linear memory
+- `array[i64]` -  `i32` pointer to an array of `i64` bytes in linear memory
+- `array[f32]` -  `i32` pointer to an array of `f32` bytes in linear memory
+- `array[f32]` -  `i32` pointer to an array of `f64` bytes in linear memory
+
+
+
+## Publication Entry
+
+The subsequent entries on the publication chain hold the remainder of the byte buffer
+
+Normal publication entries have no content.
+
+### Publication Entry External Ids
+
+| Index | Description                                                  | Encoding | Required |
+| ----- | ------------------------------------------------------------ | -------- | -------- |
+| 0     | The next 10K Bytes the buffer, or the concluding Bytes of the buffer | raw      | Y        |
+|       |                                                              |          |          |
+
+## Contract Publication Validation
+
+To validate the contract buffer:
+
+1. Retrieve the Initial Publication Entry of the contract chain
+2. Check that the Initial Publication Entry content and External Ids match the validation expected of a initial publication entry
+3. Read subsequent Publication Entries, concatenating bytes from the 0th External ID while:
+   1. Subsequent entries satisfy the Publication Entry validation
+   2. The number of bytes in the buffer is less than `bytes` specified in the initial Publication Entry
+4. Validate that the number of Bytes in the final buffer matches what is expected in `bytes`
+5. Validate that the sha512 hash of the final buffer matches what was specified in the Initial Publication Entry
+6. Validate that the buffer represents a valid WASM binary
+
+
+
+# Implementation
+
+The official [WebAssembly Toolkit (WABT)](https://github.com/WebAssembly/wabt)'s [wasm-validate](https://webassembly.github.io/wabt/doc/wasm-validate.1.html) command line tool is a very popular way of validating WASM binaries.
+
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/fatips/105.md
+++ b/fatips/105.md
@@ -1,0 +1,65 @@
+| FATIP | Title                   | Status | Category | Author                            | Created   |
+| ----- | ----------------------- | ------ | -------- | --------------------------------- | --------- |
+| 105   | Host Interface Standard | WIP    | Core     | Devon Katz\<<devonk@dbgrow.com>\> | 9-17-2019 |
+
+
+
+# Summary
+
+This standard describes the basic host interface that a WASM based contract has access to as a FAT token contract. The interface is used to allow contracts access to critical context information from the host environment, which would ordinarily be completely restricted.
+
+# Motivation
+
+FAT smart contracts have the ability to securely execute trustless logic; However, with this security comes seclusion and isolation. Contracts may need access to more context info than a single contract call's `func` and `args` can contain to do their job. 
+
+For example:
+
+- What is the calling transaction's entryhash?
+- How many tokens were sent in the transaction?
+- Who sent the transaction?
+- What is the current balance at the contract?
+- What is the current timestamp or block height?
+
+For even basic contract applications, this vital information is required. This standard seeks to define a standard namespace and set of functions & constants WASM contracs can use to conduct their operations
+
+
+
+# Specification
+
+To access the host's functions, they must be declared as external functions in the WASM code. For example, in C, this is how the contract would declare the function to return the current blockheight from the host:
+
+```c
+extern int getHeight(void);
+```
+
+The functions mentioned in this document are defined identically with a root namespace, albeit given different argument and return types.
+
+Since the interface is only is used by the host, functions may be omitted if not required by the contract.
+
+
+
+## Supported Functions
+
+| Name           | Description                                                  | Arguments (C)                                          | Return (C) | Declaration Example (C)             |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------ | ---------- | ----------------------------------- |
+| `getInput`     | Get the calling tx's input Factoid address                   | `void`                                                 | `char *`   | ```extern char * getInput(void);``` |
+| `getAmount`    | Get the calling tx's output amount to the contract's balance | `void`                                                 | `int`      |                                     |
+| `getEntryhash` | Get the calling tx's Factom Entryhash                        | `void`                                                 | `char *`   |                                     |
+| `getTimestamp` | Get the unix timestamp of the calling tx                     | `void`                                                 | `int`      |                                     |
+| `getHeight`    | Get the Factom blockheight of the calling tx                 | `void`                                                 | `int`      |                                     |
+| `getAddress`   | Get the Factoid address the current contract is hosted on    | `void`                                                 | `char *`   |                                     |
+|                |                                                              |                                                        |            |                                     |
+| `getPrecision` | Get the decimal precision of the host token                  | `void`                                                 | `int`      |                                     |
+| `getBalance`   | Get the FAT-0 balance of a Factoid address on the host token | `char *` - The Factoid address string                  | `int`      |                                     |
+| `burn`         | Burn the specified amount of tokens from the contract's balance | `int` - The amount of tokens to burn                   | `void`     |                                     |
+| `selfDestruct` | Terminate the current contract, liquidating the balance to an address | `char *` - the liquidation destination Factoid address | `void`     |                                     |
+| `revert`       | Revert the current contract calls changes and abort the call. | `void`                                                 | `void`     |                                     |
+
+
+
+# Implementation
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This commit lays the base for contracts on FAT:

- Specifies necessary changes to FAT-0, validation, operation needed to facilitate publishing and calling contracts
- Proposes a new supporting standard FATIP-104 which describes how contracts should be published to a chain, and how their ABI must be specified for usage by our system.
- Proposes a new supporting standard FATIP-105 which describes the in-contract interface for retrieving context info from the host and performing key operations for contracts